### PR TITLE
Drop media-library permission (Play policy) + self-heal admin profile

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -18,7 +18,6 @@
         "expo-font": "~14.0.12",
         "expo-haptics": "~15.0.8",
         "expo-location": "~19.0.8",
-        "expo-media-library": "~18.2.1",
         "expo-notifications": "~0.32.17",
         "expo-secure-store": "~15.0.8",
         "expo-sharing": "~14.0.8",
@@ -864,8 +863,6 @@
     "expo-location": ["expo-location@19.0.8", "", { "peerDependencies": { "expo": "*" } }, "sha512-H/FI75VuJ1coodJbbMu82pf+Zjess8X8Xkiv9Bv58ZgPKS/2ztjC1YO1/XMcGz7+s9DrbLuMIw22dFuP4HqneA=="],
 
     "expo-manifests": ["expo-manifests@1.0.11", "", { "dependencies": { "@expo/config": "~12.0.13", "expo-json-utils": "~0.15.0" }, "peerDependencies": { "expo": "*" } }, "sha512-6zItytTewN37Cjhp3glUg0ozrgW2GwB8x9wtfzUNoJIMmxO38nnGdTLMaotYhRqdf5PP2Dzdmej1HDHXVNUpRw=="],
-
-    "expo-media-library": ["expo-media-library@18.2.1", "", { "peerDependencies": { "expo": "*", "react-native": "*" } }, "sha512-dV1acx6Aseu+I5hmF61wY8UkD4vdt8d7YXHDfgNp6ZSs06qxayUxgrBsiG2eigLe54VLm3ycbFBbWi31lhfsCA=="],
 
     "expo-modules-autolinking": ["expo-modules-autolinking@3.0.26", "", { "dependencies": { "@expo/spawn-async": "^1.7.2", "chalk": "^4.1.0", "commander": "^7.2.0", "require-from-string": "^2.0.2", "resolve-from": "^5.0.0" }, "bin": { "expo-modules-autolinking": "bin/expo-modules-autolinking.js" } }, "sha512-WOaud6UKg16ciCOj8raKcMOoKFMHLXKI29U29yhgu1lf+Y7VxJyCktUcYo6AM+ccZ7zLD1uWZdMtgnpf+95OXA=="],
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "expo-font": "~14.0.12",
     "expo-haptics": "~15.0.8",
     "expo-location": "~19.0.8",
-    "expo-media-library": "~18.2.1",
     "expo-notifications": "~0.32.17",
     "expo-secure-store": "~15.0.8",
     "expo-sharing": "~14.0.8",

--- a/screens/AdminHomeScreen.js
+++ b/screens/AdminHomeScreen.js
@@ -1,5 +1,6 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useCallback } from 'react';
 import { View, Text, StyleSheet, ScrollView, TouchableOpacity } from 'react-native';
+import { useFocusEffect } from '@react-navigation/native';
 import { auth, db } from '../firebase';
 import { doc, getDoc, collection, getDocs, query, where } from 'firebase/firestore';
 import Icon from 'react-native-vector-icons/Ionicons';
@@ -34,18 +35,31 @@ export default function AdminHomeScreen({ navigation }) {
     });
   };
 
-  useEffect(() => {
-    const fetchUserData = async () => {
-      const userRef = doc(db, 'users', auth.currentUser.uid);
-      const userSnap = await getDoc(userRef);
-      if (userSnap.exists()) {
-        setUser(userSnap.data());
-      }
-    };
+  useFocusEffect(
+    useCallback(() => {
+      let active = true;
 
-    fetchUserData();
-    // fetchCounts will be called when season is available via effect below
-  }, []);
+      const fetchUserData = async () => {
+        try {
+          const uid = auth.currentUser?.uid;
+          if (!uid) return;
+          const userRef = doc(db, 'users', uid);
+          const userSnap = await getDoc(userRef);
+          if (active && userSnap.exists()) {
+            setUser(userSnap.data());
+          }
+        } catch (err) {
+          console.warn('Failed to fetch admin user data:', err);
+        }
+      };
+
+      fetchUserData();
+      // fetchCounts is driven by the currentSeason effect below
+      return () => {
+        active = false;
+      };
+    }, [])
+  );
 
   const { currentSeason, activeStage, midReleased, finalReleased } = useSeason();
   const STAGE_LABEL = { mid: 'Mid-Season', final: 'Final' };

--- a/screens/SessionDataScreen.js
+++ b/screens/SessionDataScreen.js
@@ -6,13 +6,12 @@ import {
   StyleSheet,
   ActivityIndicator,
   TouchableOpacity,
-  Platform,
 } from 'react-native';
 import { collection, query, where, getDocs, doc, getDoc } from 'firebase/firestore';
 import { db } from '../firebase';
 import XLSX from 'xlsx';
 import * as FileSystem from 'expo-file-system/legacy';
-import * as MediaLibrary from 'expo-media-library';
+import * as Sharing from 'expo-sharing';
 import AppBackgroundWrapper from '../components/AppBackgroundWrapper';
 import Icon from 'react-native-vector-icons/Ionicons';
 import * as Animatable from 'react-native-animatable';
@@ -74,15 +73,14 @@ export default function SessionDataScreen({ route }) {
         encoding: FileSystem.EncodingType.Base64,
       });
 
-      if (Platform.OS === 'android') {
-        const { status } = await MediaLibrary.requestPermissionsAsync();
-        if (status === 'granted') {
-          const asset = await MediaLibrary.createAssetAsync(uri);
-          await MediaLibrary.createAlbumAsync('Download', asset, false);
-          showBanner('success', 'Excel saved to Downloads');
-        } else {
-          showBanner('error', 'Permission denied to save file');
-        }
+      // Share via the OS share sheet — the admin can save to Files/Downloads,
+      // email it, etc. Avoids broad media-library permissions (Play policy).
+      if (await Sharing.isAvailableAsync()) {
+        await Sharing.shareAsync(uri, {
+          mimeType: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+          dialogTitle: 'Export attendance',
+          UTI: 'org.openxmlformats.spreadsheetml.sheet',
+        });
       } else {
         showBanner('success', `Excel saved to:\n${uri}`);
       }


### PR DESCRIPTION
- Remove expo-media-library; export attendance via expo-file-system (app sandbox) + expo-sharing share sheet. Eliminates READ_MEDIA_IMAGES/READ_MEDIA_VIDEO that violated Google Play's Photo and Video Permissions policy.
- AdminHomeScreen: refetch user doc on focus with try/catch + active guard so a stale/failed first fetch self-heals instead of leaving name/details blank.